### PR TITLE
fix

### DIFF
--- a/BuildFile.xml
+++ b/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="boost" />
 <use name="roofit" />
 <use name="boost_program_options" />
+<use name="boost_filesystem" />
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
adding boost_filesystem library to avoid compilation error for CMSSW_11 or later